### PR TITLE
Update sched_burst_preempt_offset default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ How strongly tasks are discriminated accordingly to their burst time ratio, scal
 Increasing this value makes burst score rapidly grow as the burst time grows. That means tasks that run longer without sleeping/yielding/iowaiting rapidly lose their power against those that run shorter.  
 Decreasing vice versa.
 
-### sched_burst_preempt_offset (range: 0 - 64, default: 16)
+### sched_burst_preempt_offset (range: 0 - 64, default: 23)
 
 How many bits of burst time in nanoseconds at minimum for the burst preempt feature to start functioning.  
 Decreasing this value may strengthen wider range of interactive tasks by reinforcing their wakeup preemption, but going too far may harm some benchmark scores.  


### PR DESCRIPTION
This commit https://github.com/firelzrd/bore-scheduler/commit/f750b274a20c4e933cfb551b9516cd8b9a79cccb changed the default value for sched_burst_preempt_offset - it would be good to correct the value in the README as well.

Thanks for the great work on my behalf and the discord group "Polish Linux Community". 