### PR TITLE
Fixed missing comments after #endif directives

### DIFF
--- a/patches/stable/linux-6.17-bore/0001-linux6.17-bore-6.5.2.patch
+++ b/patches/stable/linux-6.17-bore/0001-linux6.17-bore-6.5.2.patch
@@ -28,7 +28,7 @@ index e4ce0a7683..fa9c484128 100644
 @@ -813,6 +813,32 @@ struct kmap_ctrl {
  #endif
  };
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +#define BORE_BC_TIMESTAMP_SHIFT 16
 +
@@ -66,7 +66,7 @@ index e4ce0a7683..fa9c484128 100644
 +	struct bore_ctx			bore;
 +#endif /* CONFIG_SCHED_BORE */
  	const struct sched_class	*sched_class;
- 
+
  #ifdef CONFIG_SCHED_CORE
 diff --git a/include/linux/sched/bore.h b/include/linux/sched/bore.h
 new file mode 100644
@@ -118,9 +118,9 @@ index ecddb94db8..c34b454ba6 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1413,6 +1413,23 @@ config CHECKPOINT_RESTORE
- 
+
  	  If unsure, say N here.
- 
+
 +config SCHED_BORE
 +	bool "Burst-Oriented Response Enhancer"
 +	default y
@@ -146,7 +146,7 @@ index ce1435cb08..9eee2005e2 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -57,3 +57,20 @@ config HZ
- 
+
  config SCHED_HRTICK
  	def_bool HIGH_RES_TIMERS
 +
@@ -156,13 +156,13 @@ index ce1435cb08..9eee2005e2 100644
 +	help
 +	 The BORE Scheduler automatically calculates the optimal base
 +	 slice for the configured HZ using the following equation:
-+	 
++
 +	 base_slice_ns =
 +	 	1000000000/HZ * DIV_ROUNDUP(min_base_slice_ns, 1000000000/HZ)
-+	 
++
 +	 This option sets the default lower bound limit of the base slice
 +	 to prevent the loss of task throughput due to overscheduling.
-+	 
++
 +	 Setting this value too high can cause the system to boot with
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
@@ -173,13 +173,13 @@ index 6ca8689a83..dbcb91b689 100644
 @@ -116,6 +116,10 @@
  /* For dup_mmap(). */
  #include "../mm/internal.h"
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +#include <linux/sched/bore.h>
 +#endif /* CONFIG_SCHED_BORE */
 +
  #include <trace/events/sched.h>
- 
+
  #define CREATE_TRACE_POINTS
 @@ -2319,6 +2323,10 @@ __latent_entropy struct task_struct *copy_process(
  	 * Need tasklist lock for parent etc handling!
@@ -189,7 +189,7 @@ index 6ca8689a83..dbcb91b689 100644
 +	if (likely(p->pid))
 +		task_fork_bore(p, current, clone_flags, p->start_time);
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  	/* CLONE_PARENT re-uses the old parent */
  	if (clone_flags & (CLONE_PARENT|CLONE_THREAD)) {
 diff --git a/kernel/futex/waitwake.c b/kernel/futex/waitwake.c
@@ -203,9 +203,9 @@ index e2bbe5509e..84812b7876 100644
 +#ifdef CONFIG_SCHED_BORE
 +#include <linux/sched/bore.h>
 +#endif // CONFIG_SCHED_BORE
- 
+
  #include "futex.h"
- 
+
 @@ -355,7 +358,15 @@ void futex_do_wait(struct futex_q *q, struct hrtimer_sleeper *timeout)
  		 * is no timeout, or if it has yet to expire.
  		 */
@@ -637,16 +637,16 @@ index ccba6fc3c3..5bd3d55af4 100644
 @@ -98,6 +98,10 @@
  #include "../smpboot.h"
  #include "../locking/mutex.h"
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +#include <linux/sched/bore.h>
 +#endif /* CONFIG_SCHED_BORE */
 +
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpu);
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpumask);
- 
+
 @@ -1429,7 +1433,11 @@ int tg_nop(struct task_group *tg, void *data)
- 
+
  void set_load_weight(struct task_struct *p, bool update_load)
  {
 +#ifdef CONFIG_SCHED_BORE
@@ -655,18 +655,18 @@ index ccba6fc3c3..5bd3d55af4 100644
  	int prio = p->static_prio - MAX_RT_PRIO;
 +#endif /* CONFIG_SCHED_BORE */
  	struct load_weight lw;
- 
+
  	if (task_has_idle_policy(p)) {
 @@ -8685,6 +8693,10 @@ void __init sched_init(void)
  	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
  #endif
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +	sched_init_bore();
 +#endif /* CONFIG_SCHED_BORE */
 +
  	wait_bit_init();
- 
+
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
 index 02e16b70a7..751df396d9 100644
@@ -675,7 +675,7 @@ index 02e16b70a7..751df396d9 100644
 @@ -169,6 +169,53 @@ static const struct file_operations sched_feat_fops = {
  	.release	= single_release,
  };
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +#define DEFINE_SYSCTL_SCHED_FUNC(name, update_func) \
 +static ssize_t sched_##name##_write(struct file *filp, const char __user *ubuf, size_t cnt, loff_t *ppos) \
@@ -731,33 +731,33 @@ index 02e16b70a7..751df396d9 100644
  	.release	= single_release,
  };
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  #ifdef CONFIG_PREEMPT_DYNAMIC
- 
+
 @@ -500,12 +548,19 @@ static __init int sched_init_debug(void)
  	debugfs_create_file("preempt", 0644, debugfs_sched, NULL, &sched_dynamic_fops);
  #endif
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +	debugfs_create_file("min_base_slice_ns", 0644, debugfs_sched, NULL, &sched_min_base_slice_fops);
 +	debugfs_create_u32("base_slice_ns", 0444, debugfs_sched, &sysctl_sched_base_slice);
 +#else /* !CONFIG_SCHED_BORE */
  	debugfs_create_u32("base_slice_ns", 0644, debugfs_sched, &sysctl_sched_base_slice);
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  	debugfs_create_u32("latency_warn_ms", 0644, debugfs_sched, &sysctl_resched_latency_warn_ms);
  	debugfs_create_u32("latency_warn_once", 0644, debugfs_sched, &sysctl_resched_latency_warn_once);
- 
+
 +#if !defined(CONFIG_SCHED_BORE)
  	debugfs_create_file("tunable_scaling", 0644, debugfs_sched, NULL, &sched_scaling_fops);
 +#endif /* CONFIG_SCHED_BORE */
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
- 
+
 @@ -747,6 +802,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +	SEQ_printf(m, " %2d", p->bore.score);
 +#endif /* CONFIG_SCHED_BORE */
@@ -766,7 +766,7 @@ index 02e16b70a7..751df396d9 100644
  #endif
 @@ -1224,6 +1282,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  	__PS("nr_involuntary_switches", p->nivcsw);
- 
+
  	P(se.load.weight);
 +#ifdef CONFIG_SCHED_BORE
 +	P(bore.score);
@@ -781,7 +781,7 @@ index 8ce56a8d50..86565bf058 100644
 @@ -58,6 +58,10 @@
  #include "stats.h"
  #include "autogroup.h"
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +#include <linux/sched/bore.h>
 +#endif /* CONFIG_SCHED_BORE */
@@ -802,7 +802,7 @@ index 8ce56a8d50..86565bf058 100644
 +#else /* !CONFIG_SCHED_BORE */
  unsigned int sysctl_sched_tunable_scaling = SCHED_TUNABLESCALING_LOG;
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  /*
   * Minimal preemption granularity for CPU-bound tasks:
   *
@@ -819,9 +819,9 @@ index 8ce56a8d50..86565bf058 100644
  unsigned int sysctl_sched_base_slice			= 700000ULL;
  static unsigned int normalized_sysctl_sched_base_slice	= 700000ULL;
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  __read_mostly unsigned int sysctl_sched_migration_cost	= 500000UL;
- 
+
 @@ -189,6 +206,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
@@ -841,17 +841,17 @@ index 8ce56a8d50..86565bf058 100644
  #undef SET_SYSCTL
  }
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  void __init sched_init_granularity(void)
  {
 @@ -698,6 +723,9 @@ static void update_entity_lag(struct cfs_rq *cfs_rq, struct sched_entity *se)
- 
+
  	vlag = avg_vruntime(cfs_rq) - se->vruntime;
  	limit = calc_delta_fair(max_t(u64, 2*se->slice, TICK_NSEC), se);
 +#ifdef CONFIG_SCHED_BORE
 +	limit >>= !!sched_bore;
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  	se->vlag = clamp(vlag, -limit, limit);
  }
 @@ -891,10 +919,17 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
@@ -865,17 +865,17 @@ index 8ce56a8d50..86565bf058 100644
 +#else // CONFIG_SCHED_BORE
  	u64 slice = normalized_sysctl_sched_base_slice;
 +	bool run_to_parity = sched_feat(RUN_TO_PARITY);
-+#endif CONFIG_SCHED_BORE
++#endif // CONFIG_SCHED_BORE
  	u64 vprot = se->deadline;
- 
+
 -	if (sched_feat(RUN_TO_PARITY))
 +	if (run_to_parity)
  		slice = cfs_rq_min_slice(cfs_rq);
- 
+
  	slice = min(slice, se->slice);
 @@ -959,6 +994,11 @@ static struct sched_entity *__pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
  		curr = NULL;
- 
+
  	if (curr && protect && protect_slice(curr))
 +#ifdef CONFIG_SCHED_BORE
 +		if (!entity_is_task(curr) ||
@@ -883,7 +883,7 @@ index 8ce56a8d50..86565bf058 100644
 +			unlikely(!sched_bore))
 +#endif /* CONFIG_SCHED_BORE */
  		return curr;
- 
+
  	/* Pick the leftmost entity if it's eligible */
 @@ -1020,6 +1060,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
  /**************************************************************
@@ -894,16 +894,16 @@ index 8ce56a8d50..86565bf058 100644
  {
  	unsigned int factor = get_update_sysctl_factor();
 @@ -1031,6 +1072,7 @@ int sched_update_scaling(void)
- 
+
  	return 0;
  }
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
- 
+
 @@ -1229,6 +1271,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	update_min_vruntime(cfs_rq);
- 
+
  	if (entity_is_task(curr)) {
 +#ifdef CONFIG_SCHED_BORE
 +		struct task_struct *p = task_of(curr);
@@ -914,9 +914,9 @@ index 8ce56a8d50..86565bf058 100644
  		 * If the fair_server is active, we need to account for the
  		 * fair_server time whether or not the task is running on
 @@ -3767,7 +3814,7 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se)
- 
+
  static void place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags);
- 
+
 -static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
 +void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
  			    unsigned long weight)
@@ -929,11 +929,11 @@ index 8ce56a8d50..86565bf058 100644
 -	u64 vslice, vruntime = avg_vruntime(cfs_rq);
 +	u64 vslice = 0, vruntime = avg_vruntime(cfs_rq);
  	s64 lag = 0;
- 
+
  	if (!se->custom_slice)
  		se->slice = sysctl_sched_base_slice;
 -	vslice = calc_delta_fair(se->slice, se);
- 
+
  	/*
  	 * Due to how V is constructed as the weighted average of entities,
 @@ -5217,7 +5263,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
@@ -959,7 +959,7 @@ index 8ce56a8d50..86565bf058 100644
 @@ -5226,6 +5283,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
  		vslice /= 2;
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +vslice_found:
 +#endif /* CONFIG_SCHED_BORE */
@@ -968,11 +968,11 @@ index 8ce56a8d50..86565bf058 100644
  	 */
 @@ -5236,7 +5296,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
  static inline int cfs_rq_throttled(struct cfs_rq *cfs_rq);
- 
+
  static void
 -requeue_delayed_entity(struct sched_entity *se);
 +requeue_delayed_entity(struct sched_entity *se, int flags);
- 
+
  static void
  enqueue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
 @@ -5400,6 +5460,10 @@ dequeue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
@@ -988,16 +988,16 @@ index 8ce56a8d50..86565bf058 100644
  		}
 @@ -6785,7 +6849,7 @@ static int sched_idle_cpu(int cpu)
  }
- 
+
  static void
 -requeue_delayed_entity(struct sched_entity *se)
 +requeue_delayed_entity(struct sched_entity *se, int flags)
  {
  	struct cfs_rq *cfs_rq = cfs_rq_of(se);
- 
+
 @@ -6798,13 +6862,22 @@ requeue_delayed_entity(struct sched_entity *se)
  	WARN_ON_ONCE(!se->on_rq);
- 
+
  	if (sched_feat(DELAY_ZERO)) {
 +#ifdef CONFIG_SCHED_BORE
 +		if (likely(sched_bore))
@@ -1021,13 +1021,13 @@ index 8ce56a8d50..86565bf058 100644
  			cfs_rq->nr_queued++;
 @@ -6841,7 +6914,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_enqueue(&rq->cfs, p);
- 
+
  	if (flags & ENQUEUE_DELAYED) {
 -		requeue_delayed_entity(se);
 +		requeue_delayed_entity(se, flags);
  		return;
  	}
- 
+
 @@ -6859,7 +6932,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	for_each_sched_entity(se) {
  		if (se->on_rq) {
@@ -1039,7 +1039,7 @@ index 8ce56a8d50..86565bf058 100644
  		cfs_rq = cfs_rq_of(se);
 @@ -7077,6 +7150,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_dequeue(&rq->cfs, p);
- 
+
  	util_est_update(&rq->cfs, p, flags & DEQUEUE_SLEEP);
 +#ifdef CONFIG_SCHED_BORE
 +	struct cfs_rq *cfs_rq = &rq->cfs;
@@ -1052,20 +1052,20 @@ index 8ce56a8d50..86565bf058 100644
 +#endif /* CONFIG_SCHED_BORE */
  	if (dequeue_entities(rq, &p->se, flags) < 0)
  		return false;
- 
+
 @@ -8725,7 +8807,13 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	if (__pick_eevdf(cfs_rq, !do_preempt_short) == pse)
  		goto preempt;
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +	bool run_to_parity = likely(sched_bore) ?
 +		sched_feat(RUN_TO_PARITY_BORE) : sched_feat(RUN_TO_PARITY);
 +	if (run_to_parity && do_preempt_short)
 +#else // CONFIG_SCHED_BORE
  	if (sched_feat(RUN_TO_PARITY) && do_preempt_short)
-+#endif CONFIG_SCHED_BORE
++#endif // CONFIG_SCHED_BORE
  		update_protect_slice(cfs_rq, se);
- 
+
  	return;
 @@ -8899,16 +8987,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
@@ -1074,10 +1074,10 @@ index 8ce56a8d50..86565bf058 100644
 +#if !defined(CONFIG_SCHED_BORE)
  	if (unlikely(rq->nr_running == 1))
  		return;
- 
+
  	clear_buddies(cfs_rq, se);
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  	update_rq_clock(rq);
  	/*
  	 * Update run-time statistics of the 'current'.
@@ -1095,14 +1095,14 @@ index 8ce56a8d50..86565bf058 100644
  	 * so we don't do microscopic update in schedule()
 @@ -13156,6 +13253,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  	WARN_ON_ONCE(p->se.sched_delayed);
- 
+
  	attach_task_cfs_rq(p);
 +#ifdef CONFIG_SCHED_BORE
 +	reset_task_bore(p);
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  	set_task_max_allowed_capacity(p);
- 
+
 diff --git a/kernel/sched/features.h b/kernel/sched/features.h
 index 3c12d9f933..abadc5ca74 100644
 --- a/kernel/sched/features.h
@@ -1124,28 +1124,28 @@ index cf2109b67f..aa70f36084 100644
 @@ -2127,7 +2127,11 @@ extern int group_balance_cpu(struct sched_group *sg);
  extern void update_sched_domain_debugfs(void);
  extern void dirty_sched_domain_sysctl(int cpu);
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +extern void sched_update_min_base_slice(void);
 +#else /* !CONFIG_SCHED_BORE */
  extern int sched_update_scaling(void);
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  static inline const struct cpumask *task_user_cpus(struct task_struct *p)
  {
 @@ -2803,7 +2807,12 @@ extern void wakeup_preempt(struct rq *rq, struct task_struct *p, int flags);
  extern __read_mostly unsigned int sysctl_sched_nr_migrate;
  extern __read_mostly unsigned int sysctl_sched_migration_cost;
- 
+
 +#ifdef CONFIG_SCHED_BORE
 +extern unsigned int sysctl_sched_min_base_slice;
 +extern __read_mostly uint sysctl_sched_base_slice;
 +#else /* !CONFIG_SCHED_BORE */
  extern unsigned int sysctl_sched_base_slice;
 +#endif /* CONFIG_SCHED_BORE */
- 
+
  extern int sysctl_resched_latency_warn_ms;
  extern int sysctl_resched_latency_warn_once;
--- 
+--
 2.34.1
 


### PR DESCRIPTION
This patch removes the extra tokens after #endif CONFIG_SCHED_BORE in kernel/sched/fair.c, which were causing build errors with -Wextra-tokens. No functionality is changed; this only fixes the invalid preprocessor directives. Basically just commenting them.

I must note that my editor also automatically removed all trailing spaces.